### PR TITLE
fixed #65, fixed #68

### DIFF
--- a/src/trip_kinematics/Robot.py
+++ b/src/trip_kinematics/Robot.py
@@ -41,8 +41,9 @@ class Robot:
                 # KinematicGroup expects root of virtual children to have itself as a parent
                 group.parent = str(group)
 
-                group = OpenKinematicGroup(name=str(group), virtual_chain=[group],
-                                           parent=self._group_dict[str(kinematic_chain[i-1])])
+                group = OpenKinematicGroup(name=str(group), 
+                                           virtual_chain=[group],
+                                           parent=None)
 
                 # carefull this circumvents the usual checks for correct group and parent names!
                 group.children = group_children

--- a/src/trip_kinematics/Robot.py
+++ b/src/trip_kinematics/Robot.py
@@ -41,7 +41,7 @@ class Robot:
                 # KinematicGroup expects root of virtual children to have itself as a parent
                 group.parent = str(group)
 
-                group = OpenKinematicGroup(name=str(group), 
+                group = OpenKinematicGroup(name=str(group),
                                            virtual_chain=[group],
                                            parent=None)
 

--- a/tests/test_open_chains.py
+++ b/tests/test_open_chains.py
@@ -1,0 +1,62 @@
+import trip_kinematics as trip
+from trip_robots.triped import triped
+
+
+def test_open_chain_builder():
+    first_trafo = trip.Transformation(name='first_trafo',
+                                      values={'tx': 0},
+                                      state_variables=['tx'])
+    second_trafo = trip.Transformation(name='second_trafo',
+                                       parent=first_trafo,
+                                       values={'ty': 0},
+                                       state_variables=['ty'])
+    third_trafo = trip.Transformation(name='third_trafo',
+                                      parent=second_trafo,
+                                      values={'rx': 0},
+                                      state_variables=['rx'])
+    fourth_trafo = trip.Transformation(name='fourth_trafo',
+                                       parent=second_trafo,
+                                       values={'qw': 0},
+                                       state_variables=['qw'])
+
+    transformations = [first_trafo, second_trafo, third_trafo, fourth_trafo]
+    robot = trip.Robot(transformations)
+
+    expected_virtual_state = {'first_trafo': {'tx': 0},
+                              'second_trafo': {'ty': 0},
+                              'third_trafo': {'rx': 0},
+                              'fourth_trafo': {'qw': 0}}
+
+    expected_actuated_state = {'first_trafo_tx': 0,
+                               'second_trafo_ty': 0,
+                               'third_trafo_rx': 0,
+                               'fourth_trafo_qw': 0}
+
+    virtual_as_expceted = robot.get_virtual_state() == expected_virtual_state
+    actuated_as_expected = robot.get_actuated_state() == expected_actuated_state
+    assert virtual_as_expceted and actuated_as_expected
+
+
+def test_child_relation():
+    groups = triped.get_groups()
+    children_list = []
+    for group in groups.values():
+        children_list.append(group.children)
+
+    expected_children = [['leg_0_A_P_LL'],
+                         ['leg_0_A_LL_Joint_FCS'],
+                         [],
+                         ['leg_0_zero_angle_convention'],
+                         ['leg_0_extend_joint'],
+                         ['leg_1_A_P_LL'],
+                         ['leg_1_A_LL_Joint_FCS'],
+                         [],
+                         ['leg_1_zero_angle_convention'],
+                         ['leg_1_extend_joint'],
+                         ['leg_2_A_P_LL'],
+                         ['leg_2_A_LL_Joint_FCS'],
+                         [],
+                         ['leg_2_zero_angle_convention'],
+                         ['leg_2_extend_joint']]
+
+    assert sorted(expected_children) == sorted(children_list)


### PR DESCRIPTION
While I still stand by the statement in the [other pull request](https://github.com/TriPed-Robot/trip_kinematics/pull/66#pullrequestreview-795243613)

The fact that the same error causes troubles for purely open chains, means that a temporary fix is still advisable.
I have also added tests that should help create a better solution down the line
